### PR TITLE
Inject CLI version from GoReleaser tag metadata

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,8 @@ builds:
   - env:
       - CGO_ENABLED=0
     binary: kubestate
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
 
 archives:
   - formats: [tar.gz]

--- a/main.go
+++ b/main.go
@@ -18,11 +18,13 @@ import (
 	"time"
 )
 
+var version = "dev"
+
 func newApp() *cli.App {
 	app := cli.NewApp()
 	app.Name = "kubestate"
 	app.Usage = "Show kubernetes state metrics"
-	app.Version = "0.0.4"
+	app.Version = version
 	app.Compiled = time.Now()
 
 	app.Flags = []cli.Flag{


### PR DESCRIPTION
Summary:
- replace hardcoded app version with build-time variable in main.go
- default local version to dev
- configure GoReleaser ldflags to inject tag version into main.version

Validation:
- go test ./...